### PR TITLE
Bridges should go to the logically closest key of next column

### DIFF
--- a/dometyl/lib/generator/plate.ml
+++ b/dometyl/lib/generator/plate.ml
@@ -223,13 +223,13 @@ let column_joins ?in_d ?out_d1 ?out_d2 { config = { n_cols; _ }; columns; _ } =
   let join = Bridge.cols ?in_d ?out_d1 ?out_d2 ~columns in
   Scad.union (List.init ~f:(fun i -> join i (i + 1)) (n_cols - 1))
 
-let skeleton_bridges ?in_d ?out_d1 ?out_d2 { config = { n_rows; n_cols; _ }; columns; _ } =
+let skeleton_bridges ?in_d ?out_d1 ?out_d2 { config = { row_centres; n_rows; n_cols; _ }; columns; _ } =
   let bridge c first =
     let r = if first then fun _ -> 0 else fun i -> n_rows i - 1 in
     Option.map2
       ~f:(Bridge.keys ?in_d ?out_d1 ?out_d2)
       (Columns.key columns c (r c))
-      (Columns.key columns (c + 1) (r (c + 1)))
+      (Columns.key columns (c + 1) (r c + Int.of_float (Float.round (row_centres (c+1) -. row_centres c))))
   in
   List.init ~f:(fun i -> bridge i (i < 2)) (n_cols - 1) |> List.filter_opt |> Scad.union
 


### PR DESCRIPTION
When using columns of different sizes, and thus different center values, the bridge between columns would look very seriously slanted (because key of logical row index r is linked with key of logical row index r + 1 of the next column).

This patch proposes to use the center config value to decide which key is closest in the next row.

Some possible improvement: also take into account the y-offsets of the columns.

The reason why I did not consider using the y-offsets is that, when I wrote this patch, I had not pulled the recent changes that made "center" into a float (so, just a mere geometrical adjustment), when it used to be an int (sounding like having a deeper semantics, with respect to logical rows). Now the y-offset and center offset seem to have very similar roles...

Anyway, this change works well for my configuration (where actual center values are integers).